### PR TITLE
Fix increment of progress args in GetCategories

### DIFF
--- a/src/microsoft-update-upstream-package-source/Sources/UpstreamCategoriesSource.cs
+++ b/src/microsoft-update-upstream-package-source/Sources/UpstreamCategoriesSource.cs
@@ -121,7 +121,7 @@ namespace Microsoft.PackageGraph.MicrosoftUpdate.Source
 
                 lock (progressArgs)
                 {
-                    progressArgs.Current++;
+                    progressArgs.Current += retrievedBatch.Count;
                     MetadataCopyProgress?.Invoke(this, progressArgs);
                 }
             });


### PR DESCRIPTION
`progressArgs` is only incremented by one, however the logic in `GetCategories` is executing batches of multiple updates at a time.

Corrects `GetCategories` to use the same logic as `CopyTo` so that progress accurately reflects how many categories have been retrieved.